### PR TITLE
Migrate to v6 transport.rest API and refactor onto the api package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently we are offering binary (pre-)releases and the source code. The binary 
 To install from source you need to have a current Go version installed.
 
 ```bash
-go get -u github.com/noxer/departures
+go install github.com/noxer/departures@latest
 ```
 Now you should have the `departures` binary installed in your `$GOPATH/bin` directory. You can call it from there or add the directory to your `$PATH`.
 
@@ -17,17 +17,17 @@ First you need to find out the ID of your station. To do this run the tool with 
 ```bash
 ~$ departures -search="Alexanderplatz"
 Found 5 station(s):
-  900000100003 - S+U Alexanderplatz
-  900000100024 - S+U Alexanderplatz/Dircksenstr.
-  900000100026 - S+U Alexanderplatz/Gontardstr.
-  900000100005 - U Alexanderplatz [Tram]
-  900000100031 - S+U Alexanderplatz/Memhardstr.
+  900100003 - S+U Alexanderplatz
+  900100024 - S+U Alexanderplatz/Dircksenstr.
+  900100026 - S+U Alexanderplatz/Gontardstr.
+  900100005 - U Alexanderplatz [Tram]
+  900100031 - S+U Alexanderplatz/Memhardstr.
 ```
 
 This should help you identify the station you want to look at. Now you can request the timetable for Alexanderplatz.
 
 ```bash
-~$ departures -id="900000100003"
+~$ departures -id="900100003"
   M6 S Hackescher Markt                          10:19 (-1)
   S7 S Potsdam Hauptbahnhof                      10:20
   U2 U Ruhleben                                  10:20
@@ -40,7 +40,7 @@ This should help you identify the station you want to look at. Now you can reque
 You can limit the lines and directions shown. Multiple values must be separated by a comma.
 
 ```bash
-~$ departures -id="900000100003" -filter-line="M4" -filter-destination="S Hackescher Markt"
+~$ departures -id="900100003" -filter-line="M4" -filter-destination="S Hackescher Markt"
 M4 S Hackescher Markt 10:57 (-1)
 M4 S Hackescher Markt 11:02 (-1)
 M4 S Hackescher Markt 11:07 (-1)
@@ -68,7 +68,7 @@ You can limit the width of the output to make it fit your terminal or for use in
 (* wtfutil sets the `WTF_WIDGET_WIDTH` environment variable which is automatically recognized by departures)
 
 ```bash
-~$ departures -id="900000100003" -width=20
+~$ departures -id="900100003" -width=20
   S5 S We 10:58
  100 S+U  10:58
  RE1 Fran 10:59 (+1)
@@ -77,7 +77,7 @@ You can limit the width of the output to make it fit your terminal or for use in
 You can filter only connections that allow you to take a bike by adding the '-bicycle' argument.
 
 ```bash
-~$ departures -id 900000029305
+~$ departures -id 900029305
 M32 S+U Rathaus Spandau    20:02
 M32 Staaken, Heidebergplan 20:10 (-1)
 M32 S+U Rathaus Spandau    20:20
@@ -88,7 +88,7 @@ RE4 Ludwigsfelde, Bhf      20:44
 M32 Staaken, Heidebergplan 20:51
 M32 S+U Rathaus Spandau    21:00
 
-~$ departures -id 900000029305 -bicycle
+~$ departures -id 900029305 -bicycle
 RE4 Rathenow, Bhf     20:25 (+11)
 RE4 Ludwigsfelde, Bhf 20:44
 ```
@@ -96,11 +96,11 @@ RE4 Ludwigsfelde, Bhf 20:44
 You can show additional informations like warning bicycle conveyance etc. by adding the '-verbose' argument
 
 ```bash
-~$ departures -id 900000029305
+~$ departures -id 900029305
 M32 S+U Rathaus Spandau    20:20
 RE4 Rathenow, Bhf          20:23 (+9)
 
-~$ departures -id 900000029305 -verbose
+~$ departures -id 900029305 -verbose
 M32 S+U Rathaus Spandau    20:20
     Operator : Berliner Verkehrsbetriebe
     Type     : bus
@@ -118,7 +118,7 @@ This utility was originally created for use in wtfutil. You can use the followin
 
 ```yml
     departures:
-      args: ["-id=900000100003", "-force-color", "-retries=100", "-retry-pause=5s"]
+      args: ["-id=900100003", "-force-color", "-retries=100", "-retry-pause=5s"]
       cmd: "departures"
       enabled: true
       position:
@@ -132,4 +132,4 @@ This utility was originally created for use in wtfutil. You can use the followin
 ```
 
 ## attribution
-We're using https://v5.bvg.transport.rest to request the current timetable data. Thanks to [derhuerst](https://github.com/derhuerst).
+We're using https://v6.vbb.transport.rest to request the current timetable data. Thanks to [derhuerst](https://github.com/derhuerst).

--- a/api/api.go
+++ b/api/api.go
@@ -33,7 +33,7 @@ func New(network Network) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) getJSON(ctx context.Context, v interface{}, urlFormat string, values ...interface{}) (err error) {
+func (c *Client) getJSON(ctx context.Context, v any, urlFormat string, values ...any) (err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, string(c.n)+fmt.Sprintf(urlFormat, values...), nil)
 	if err != nil {
 		return err

--- a/api/api.go
+++ b/api/api.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
+// Network is the base URL of a transport.rest API, scheme included.
 type Network string
 
 const (
-	NetworkVBB Network = "v5.vbb.transport.rest"
+	// NetworkVBB covers the whole Berlin-Brandenburg region (incl. regional trains).
+	NetworkVBB Network = "https://v6.vbb.transport.rest"
+	// NetworkBVG covers Berlin's local transit only (U-Bahn, tram, bus, S-Bahn).
+	NetworkBVG Network = "https://v6.bvg.transport.rest"
 )
 
 type Client struct {
@@ -21,7 +26,9 @@ type Client struct {
 
 func New(network Network) (*Client, error) {
 	return &Client{
-		c: http.DefaultClient,
+		// A timeout keeps a stalled upstream from hanging the CLI forever and
+		// lets the caller's retry loop actually kick in.
+		c: &http.Client{Timeout: 30 * time.Second},
 		n: network,
 	}, nil
 }
@@ -40,6 +47,13 @@ func (c *Client) getJSON(ctx context.Context, v interface{}, urlFormat string, v
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
+
+	// The API answers errors with a JSON body, but decoding it into the caller's
+	// type would silently yield a zero value. Surface the status instead.
+	if resp.StatusCode >= http.StatusBadRequest {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("api: unexpected status %s: %s", resp.Status, snippet)
+	}
 
 	d := json.NewDecoder(resp.Body)
 	return d.Decode(v)

--- a/api/departures.go
+++ b/api/departures.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Remark is a hint or warning attached to a departure (e.g. bicycle conveyance).
+type Remark struct {
+	Type string `json:"type"`
+	Code string `json:"code"`
+	Text string `json:"text"`
+}
+
+// Operator is the company running a line.
+type Operator struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Line describes the transit line of a departure.
+type Line struct {
+	Type     string   `json:"type"`
+	ID       string   `json:"id"`
+	FahrtNr  string   `json:"fahrtNr"`
+	Name     string   `json:"name"`
+	Public   bool     `json:"public"`
+	Mode     string   `json:"mode"`
+	Product  string   `json:"product"`
+	Operator Operator `json:"operator"`
+}
+
+// Departure is a single upcoming departure at a stop.
+type Departure struct {
+	TripID    string    `json:"tripId"`
+	Stop      Location  `json:"stop"`
+	When      time.Time `json:"when"`
+	Direction string    `json:"direction"`
+	Line      Line      `json:"line"`
+	Remarks   []Remark  `json:"remarks"`
+	Delay     int       `json:"delay"`
+	Platform  string    `json:"platform"`
+}
+
+type departuresQuery struct {
+	c        *Client
+	id       string
+	duration int
+	results  int
+	language string
+}
+
+// Departures builds a query for the upcoming departures at the stop with the given ID.
+func (c *Client) Departures(id string) *departuresQuery {
+	return &departuresQuery{
+		c:        c,
+		id:       id,
+		duration: 60,
+		results:  0, // 0 means "no limit" — let duration decide.
+		language: "en",
+	}
+}
+
+// departuresResponse wraps the v6 departures payload, which is an object
+// ({ "departures": [...], "realtimeDataUpdatedAt": ... }) rather than a bare array.
+type departuresResponse struct {
+	Departures []Departure `json:"departures"`
+}
+
+func (q *departuresQuery) Do(ctx context.Context) ([]Departure, error) {
+	const u = "/stops/%s/departures?duration=%d&language=%s&pretty=false%s"
+
+	// Only cap the number of results when asked; otherwise let duration decide,
+	// matching the API default (an unset results means "no limit").
+	results := ""
+	if q.results > 0 {
+		results = fmt.Sprintf("&results=%d", q.results)
+	}
+
+	var resp departuresResponse
+	err := q.c.getJSON(ctx, &resp, u, q.id, q.duration, q.language, results)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Departures, nil
+}
+
+func (q *departuresQuery) Duration(d int) *departuresQuery {
+	q.duration = d
+	return q
+}
+
+func (q *departuresQuery) Results(r int) *departuresQuery {
+	q.results = r
+	return q
+}
+
+func (q *departuresQuery) Language(l string) *departuresQuery {
+	q.language = l
+	return q
+}

--- a/api/stopsnearby.go
+++ b/api/stopsnearby.go
@@ -46,7 +46,7 @@ func (c *Client) StopsNearby(latitude, longitude float64) *stopsNearbyQuery {
 }
 
 func (q *stopsNearbyQuery) Do(ctx context.Context) ([]StopNearby, error) {
-	const u = "/stops/nearby?latitude=%f&longitude=%f&results=%d&distance=%s&stops=%t&poi=%t&linesOfStops=%t&language=%s&pretty=false"
+	const u = "/locations/nearby?latitude=%f&longitude=%f&results=%d&distance=%s&stops=%t&poi=%t&linesOfStops=%t&language=%s&pretty=false"
 
 	distance := ""
 	if q.distance > 0 {

--- a/departures.go
+++ b/departures.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -35,12 +36,8 @@ func main() {
 	flag.Parse()
 
 	// ensure valid retry values
-	if *retries < 0 {
-		*retries = 0
-	}
-	if *retryPause < 0 {
-		*retryPause = 0
-	}
+	*retries = max(*retries, 0)
+	*retryPause = max(*retryPause, 0)
 
 	// create the API client for the VBB network (Berlin-Brandenburg)
 	client, err := api.New(api.NetworkVBB)
@@ -88,7 +85,7 @@ func main() {
 
 	// request the departures
 	var deps []api.Departure
-	for i := 0; i < *retries+1; i++ {
+	for range *retries + 1 {
 		deps, err = client.Departures(*id).Duration(*min).Do(ctx)
 		if err == nil {
 			break
@@ -282,24 +279,13 @@ func filterSlice(filter string) []string {
 }
 
 func isFiltered(filter []string, v string) bool {
-	if len(filter) == 0 {
-		return false
-	}
-
-	for _, f := range filter {
-		if strings.EqualFold(f, v) {
-			return false
-		}
-	}
-	return true
+	return len(filter) > 0 && !slices.ContainsFunc(filter, func(f string) bool {
+		return strings.EqualFold(f, v)
+	})
 }
 
 func maxStringLen(s string, l int) int {
-	c := utf8.RuneCountInString(s)
-	if c > l {
-		return c
-	}
-	return l
+	return max(l, utf8.RuneCountInString(s))
 }
 
 func intEnv(key string) int {
@@ -308,10 +294,7 @@ func intEnv(key string) int {
 }
 
 func filterBike(r api.Departure) bool {
-	for _, rem := range r.Remarks {
-		if strings.TrimSpace(rem.Code) == "FK" {
-			return false
-		}
-	}
-	return true
+	return !slices.ContainsFunc(r.Remarks, func(rem api.Remark) bool {
+		return strings.TrimSpace(rem.Code) == "FK"
+	})
 }

--- a/departures.go
+++ b/departures.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/fatih/color"
+	"github.com/noxer/departures/api"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"gopkg.in/AlecAivazis/survey.v1"
@@ -42,11 +42,17 @@ func main() {
 		*retryPause = 0
 	}
 
-	var err error
+	// create the API client for the VBB network (Berlin-Brandenburg)
+	client, err := api.New(api.NetworkVBB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
 
 	// check if the user just wants to find the station ID
 	if *search != "" {
-		stations, err := searchStations(*search)
+		stations, err := searchStations(ctx, client, *search)
 		if err != nil {
 			fmt.Println("Could not query stations")
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
@@ -63,7 +69,7 @@ func main() {
 
 	// search of the station and provide user option to choose
 	if *id == "" && *stationName != "" {
-		s, err := promptForStation(*stationName)
+		s, err := promptForStation(ctx, client, *stationName)
 		if err != nil {
 			fmt.Println(err)
 		} else {
@@ -73,17 +79,17 @@ func main() {
 
 	// set default id if empty
 	if *id == "" {
-		fmt.Println("station ID is empty. Defaulting to: 900000100003")
-		*id = "900000100003"
+		fmt.Println("station ID is empty. Defaulting to: 900100003")
+		*id = "900100003"
 	}
 
 	// set the color mode
 	color.NoColor = color.NoColor && !*forceColor
 
 	// request the departures
-	var deps []result
+	var deps []api.Departure
 	for i := 0; i < *retries+1; i++ {
-		err = getJSON(&deps, "https://v5.vbb.transport.rest/stops/%s/departures?duration=%d", *id, *min)
+		deps, err = client.Departures(*id).Duration(*min).Do(ctx)
 		if err == nil {
 			break
 		}
@@ -195,15 +201,12 @@ func main() {
 	}
 }
 
-func searchStations(name string) ([]station, error) {
-	var stations []station
-	err := getJSON(&stations, "https://v5.vbb.transport.rest/locations?query=%s&poi=false&addresses=false", name)
-
-	return stations, err
+func searchStations(ctx context.Context, client *api.Client, name string) ([]api.Location, error) {
+	return client.Locations(name).Addresses(false).POI(false).Do(ctx)
 }
 
-func promptForStation(name string) (*station, error) {
-	stations, err := searchStations(name)
+func promptForStation(ctx context.Context, client *api.Client, name string) (*api.Location, error) {
+	stations, err := searchStations(ctx, client, name)
 	if err != nil {
 		return nil, fmt.Errorf("could not query stations")
 	}
@@ -217,9 +220,9 @@ func promptForStation(name string) (*station, error) {
 	// set first result as fallback
 	fallback := stations[0].Name
 
-	// convert to map[string]station to get station after user prompt
+	// convert to map[string]api.Location to get station after user prompt
 	var options []string
-	optionStation := map[string]station{}
+	optionStation := map[string]api.Location{}
 	for _, s := range stations {
 		options = append(options, s.Name)
 		optionStation[s.Name] = s
@@ -241,90 +244,6 @@ func promptForStation(name string) (*station, error) {
 	return &s, nil
 }
 
-func getJSON(v interface{}, urlFormat string, values ...interface{}) error {
-	resp, err := http.Get(fmt.Sprintf(urlFormat, values...))
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	d := json.NewDecoder(resp.Body)
-	return d.Decode(v)
-}
-
-type result struct {
-	TripID string `json:"tripId"`
-	Stop   struct {
-		Type     string `json:"type"`
-		ID       string `json:"id"`
-		Name     string `json:"name"`
-		Location struct {
-			Type      string  `json:"type"`
-			ID        string  `json:"id"`
-			Latitude  float64 `json:"latitude"`
-			Longitude float64 `json:"longitude"`
-		} `json:"location"`
-		Products struct {
-			Suburban bool `json:"suburban"`
-			Subway   bool `json:"subway"`
-			Tram     bool `json:"tram"`
-			Bus      bool `json:"bus"`
-			Ferry    bool `json:"ferry"`
-			Express  bool `json:"express"`
-			Regional bool `json:"regional"`
-		} `json:"products"`
-	} `json:"stop"`
-	When      time.Time `json:"when"`
-	Direction string    `json:"direction"`
-	Line      struct {
-		Type     string `json:"type"`
-		ID       string `json:"id"`
-		FahrtNr  string `json:"fahrtNr"`
-		Name     string `json:"name"`
-		Public   bool   `json:"public"`
-		Mode     string `json:"mode"`
-		Product  string `json:"product"`
-		Operator struct {
-			Type string `json:"type"`
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"operator"`
-		Symbol  string `json:"symbol"`
-		Nr      int    `json:"nr"`
-		Metro   bool   `json:"metro"`
-		Express bool   `json:"express"`
-		Night   bool   `json:"night"`
-	} `json:"line"`
-	Remarks []struct {
-		Type string `json:"type"`
-		Code string `json:"code"`
-		Text string `json:"text"`
-	} `json:"remarks"`
-	Delay    int    `json:"delay"`
-	Platform string `json:"platform"`
-}
-
-type station struct {
-	Type     string `json:"type"`
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Location struct {
-		Type      string  `json:"type"`
-		ID        string  `json:"id"`
-		Latitude  float64 `json:"latitude"`
-		Longitude float64 `json:"longitude"`
-	} `json:"location"`
-	Products struct {
-		Suburban bool `json:"suburban"`
-		Subway   bool `json:"subway"`
-		Tram     bool `json:"tram"`
-		Bus      bool `json:"bus"`
-		Ferry    bool `json:"ferry"`
-		Express  bool `json:"express"`
-		Regional bool `json:"regional"`
-	} `json:"products"`
-}
-
 func leftPad(s string, l int) string {
 	r := []rune(s)
 	if len(r) >= l {
@@ -343,7 +262,7 @@ func rightPad(s string, l int) string {
 	return string(r) + strings.Repeat(" ", l-len(r))
 }
 
-func departureTime(r result) string {
+func departureTime(r api.Departure) string {
 	if r.Delay == 0 {
 		return r.When.Format("15:04")
 	}
@@ -388,9 +307,9 @@ func intEnv(key string) int {
 	return i
 }
 
-func filterBike(r result) bool {
+func filterBike(r api.Departure) bool {
 	for _, rem := range r.Remarks {
-		if strings.TrimSpace(rem.Code) == "FB" {
+		if strings.TrimSpace(rem.Code) == "FK" {
 			return false
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/noxer/departures
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.26.4
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
Move off the deprecated v5.vbb.transport.rest API (hardcoded URLs in departures.go) to v6, routing all HTTP access through the previously unused api package.

- api: define NetworkVBB (default, whole Berlin-Brandenburg region) and NetworkBVG constants with the https scheme baked in; surface non-2xx responses as errors instead of silently decoding a zero value; give the http.Client a 30s timeout so a stalled upstream can't hang the CLI and the retry loop actually kicks in
- api/departures.go: new Departures builder + Departure type that unwrap the v6 response object ({"departures": [...], ...}), which replaced the bare array returned by v5
- api/stopsnearby.go: /stops/nearby -> /locations/nearby
- departures.go: refactor onto the client; drop the duplicated local getJSON/result/station types; default to the v6 Alexanderplatz id 900100003; match the current bicycle-conveyance remark code FK (was FB)
- README: v6 station ids, v6.vbb.transport.rest, and `go install ...@latest`

Verified live against v6.vbb (search + departures render, graceful errors) and via an offline decode of a captured v6 payload for the verbose/bicycle fields.

AI Disclosure: Clanker wrote this